### PR TITLE
Lightweight Generics

### DIFF
--- a/objc/oclib/Makefile.kmk
+++ b/objc/oclib/Makefile.kmk
@@ -17,6 +17,6 @@ oclib_SOURCES = casestmt.m datadef.m forstmt.m msgxpr.m propdef.m stmt.m \
     enumtor.m gattrib.m listxpr.m pointer.m stardecl.m util.m blockxpr.m \
     cppdirec.m expr.m globdef.m methdef.m precdecl.m stclass.m var.m \
     btincall.m dasmstmt.m exprstmt.m gotostmt.m method.m precxpr.m \
-    whilstmt.m protodef.m prdotxpr.m encxpr.m gendecl.m
+    whilstmt.m protodef.m prdotxpr.m encxpr.m gendecl.m genspec.m
 
 include $(FILE_KBUILD_SUB_FOOTER)

--- a/objc/oclib/assign.m
+++ b/objc/oclib/assign.m
@@ -96,9 +96,10 @@
             warn ("downcasting object of parent class %s to derived class %s",
                   [lhsCls classname], [rhsCls classname]);
         else if (![lhsCls isRelated:rhsCls])
-            warn ("assigning object of unrelated class %s to identifier of "
-                  "class %s",
-                  [lhsCls classname], [rhsCls classname]);
+            warnat (rhs,
+                    "assigning object of unrelated class %s to identifier of "
+                    "class %s",
+                    [rhsCls classname], [lhsCls classname]);
     }
 
     return self;

--- a/objc/oclib/classdef.h
+++ b/objc/oclib/classdef.h
@@ -22,6 +22,8 @@ extern id curstruct;
 @class Selector;
 @class OrdCltn;
 
+#include "Dictionary.h"
+
 @interface ClassDef : Node
 {
     id unit;
@@ -63,7 +65,7 @@ extern id curstruct;
     long offset;
 }
 
-@property OrdCltn * generics;
+@property Dictionary * generics;
 
 - (int)compare:c;
 

--- a/objc/oclib/classdef.m
+++ b/objc/oclib/classdef.m
@@ -1342,7 +1342,7 @@ static BOOL checkUpCast (ClassDef * one, ClassDef * two)
 
 static BOOL checkRelation (ClassDef * one, ClassDef * two)
 {
-    ClassDef *superOne;
+    ClassDef * superOne;
     if (!one || !two)
         return YES;
     else if (one == two)

--- a/objc/oclib/classdef.m
+++ b/objc/oclib/classdef.m
@@ -1342,7 +1342,7 @@ static BOOL checkUpCast (ClassDef * one, ClassDef * two)
 
 static BOOL checkRelation (ClassDef * one, ClassDef * two)
 {
-    ClassDef *superOne, *superTwo;
+    ClassDef *superOne;
     if (!one || !two)
         return YES;
     else if (one == two)

--- a/objc/oclib/decl.h
+++ b/objc/oclib/decl.h
@@ -41,8 +41,6 @@
 - gendef:sym;
 - genabstrtype;
 - hide:sym rename:x;
-- st80;
-- st80inits;
 
 - (String *)asDefFor:sym;
 

--- a/objc/oclib/decl.m
+++ b/objc/oclib/decl.m
@@ -28,6 +28,8 @@
 
 - abstrdecl { return [self subclassResponsibility:_cmd]; }
 
+- (String *)asDefFor:sym { return [self subclassResponsibility:_cmd]; }
+
 - (BOOL)isinit { return NO; }
 
 - (BOOL)islistinit { return NO; }
@@ -55,9 +57,5 @@
 - synth { return [self subclassResponsibility:_cmd]; }
 
 - synthinits { return self; }
-
-- st80 { return [self subclassResponsibility:_cmd]; }
-
-- st80inits { return self; }
 
 @end

--- a/objc/oclib/gendecl.h
+++ b/objc/oclib/gendecl.h
@@ -1,9 +1,10 @@
 /* Copyright (c) 2016 D. Mackay. All rights reserved. */
 
-#pragma once
-
 #include "decl.h"
 #include "symbol.h"
+
+#ifndef GENDECL_H_
+#define GENDECL_H_
 
 @interface GenericDecl : Decl
 {
@@ -17,3 +18,5 @@
 - gen;
 
 @end
+
+#endif

--- a/objc/oclib/gendecl.m
+++ b/objc/oclib/gendecl.m
@@ -85,6 +85,8 @@
 {
     String * aType = [String new];
 
+    [aType concat:"*genericiser*"];
+
     if (decl)
     {
         [aType concat:[decl asDefFor:sym]];

--- a/objc/oclib/gendecl.m
+++ b/objc/oclib/gendecl.m
@@ -85,7 +85,7 @@
 {
     String * aType = [String new];
 
-    [aType concat:"*genericiser*"];
+    [aType concat:[String sprintf:"<%s>", [sym str]]];
 
     if (decl)
     {

--- a/objc/oclib/genspec.h
+++ b/objc/oclib/genspec.h
@@ -1,0 +1,21 @@
+/* Copyright (c) 2016 D. Mackay. All rights reserved. */
+
+#include "node.h"
+
+#ifndef GENSPEC_H_
+#define GENSPEC_H_
+
+@class OrdCltn;
+
+@interface GenericSpec : Node
+
+/* Ordered from 0 upwards, the OrdCltn here stores a Type * for each generic
+ * argument (i.e. <arg0, arg1, ... arg99). */
+@property OrdCltn * types;
+
+- synth;
+- gen;
+
+@end
+
+#endif

--- a/objc/oclib/genspec.m
+++ b/objc/oclib/genspec.m
@@ -1,0 +1,29 @@
+/* Copyright (c) 2016 D. Mackay. All rights reserved. */
+
+#include "OCString.h"
+#include "OrdCltn.h"
+#include "genspec.h"
+
+@implementation GenericSpec
+
+- (uintptr_t)hash { return [types hash] ?: 101; }
+
+- (STR)str { return "Generic Specialisator"; }
+
+- (BOOL)isEqual:x
+{
+    if (![x isKindOf:GenericSpec])
+        return NO;
+    return types ? [types isEqual:[x types]] : YES;
+}
+
+- synth
+{
+    //[types elementsPerform:print];
+    [types elementsPerform:_cmd];
+    return self;
+}
+
+- gen { return self; }
+
+@end

--- a/objc/oclib/genspec.m
+++ b/objc/oclib/genspec.m
@@ -2,13 +2,29 @@
 
 #include "OCString.h"
 #include "OrdCltn.h"
+#include "sequence.h"
+#include "type.h"
 #include "genspec.h"
 
 @implementation GenericSpec
 
 - (uintptr_t)hash { return [types hash] ?: 101; }
 
-- (STR)str { return "Generic Specialisator"; }
+- (STR)str
+{
+    Type * aType;
+    Sequence * typeSeq = [types eachElement];
+    String * desc      = @"<";
+
+    while ((aType = [typeSeq next]))
+    {
+        [desc concat:[aType asDefFor:nil]];
+        if ([typeSeq peek])
+            [desc concat:@", "];
+    }
+
+    return [[desc concat:@">"] str];
+}
 
 - (BOOL)isEqual:x
 {

--- a/objc/oclib/globdef.h
+++ b/objc/oclib/globdef.h
@@ -33,6 +33,5 @@
 
 - type:t;
 - initializer:d;
-- reset;
 
 @end

--- a/objc/oclib/globdef.m
+++ b/objc/oclib/globdef.m
@@ -61,10 +61,4 @@
     return self;
 }
 
-- reset
-{
-    value = [type zero];
-    return self;
-}
-
 @end

--- a/objc/oclib/msgxpr.m
+++ b/objc/oclib/msgxpr.m
@@ -268,13 +268,13 @@ id msgwraps; /* VICI */
                     [methType genDeclForClass:[[rcvr type] getClass]];
                 methType =
                     pType ? [generics at:[[pType decl] index]] : methType;
-                printf ("pType: %p\n", pType);
+                dbg ("pType: %p\n", pType);
             }
 
             if (![argType isTypeEqual:methType])
             {
-                printf ("[[msg argAt:i] expr] = %s\n",
-                        [[[msg argAt:i] expr] str]);
+                dbg ("[[msg argAt:i] expr] = %s\n",
+                       [[[msg argAt:i] expr] str]);
                 warnat (msg, "incompatible type '%s' specified to '%s:(%s)' ",
                         [[argType asDefFor:nil] str],
                         [[[msg argAt:i] keyw] str],

--- a/objc/oclib/msgxpr.m
+++ b/objc/oclib/msgxpr.m
@@ -46,6 +46,9 @@
 #include "keywxpr.h"
 #include "decl.h"
 #include "keywdecl.h"
+#include "genspec.h"
+#include "gendecl.h"
+#include "OrdCltn.h"
 
 id msgwraps; /* VICI */
 
@@ -187,6 +190,7 @@ id msgwraps; /* VICI */
 
 - synth
 {
+    OrdCltn * generics = 0;
     int i;
     /* find prototype */
     method = [self method];
@@ -231,6 +235,17 @@ id msgwraps; /* VICI */
                     "selector %s may not be understood by object of class %s",
                     [sel str], [[[rcvr type] getClass] classname]);
 
+    if ([[rcvr type] isGenSpec])
+    {
+        size_t numGen = [[[[rcvr type] getClass] generics] size];
+        generics = [[[rcvr type] getGenSpec] types];
+        if (numGen != [generics size])
+            fatalat (rcvr, "%s is specialised for %d types, but class %s is "
+                           "specialised against %d types",
+                     [rcvr str], [generics size],
+                     [[[rcvr type] getClass] classname], numGen);
+    }
+
     msg = [msg synth];
 
     if (method)
@@ -244,7 +259,19 @@ id msgwraps; /* VICI */
                 ([(KeywDecl *)[method argAt:i] cast] ?: [[method argAt:i] type])
                     ?: t_id;
 
-            if (argType && ![argType isTypeEqual:methType])
+            if (!argType || !methType)
+                break;
+
+            if (generics)
+            {
+                Type * pType =
+                    [methType genDeclForClass:[[rcvr type] getClass]];
+                methType =
+                    pType ? [generics at:[[pType decl] index]] : methType;
+                printf ("pType: %p\n", pType);
+            }
+
+            if (![argType isTypeEqual:methType])
             {
                 printf ("[[msg argAt:i] expr] = %s\n",
                         [[[msg argAt:i] expr] str]);

--- a/objc/oclib/msgxpr.m
+++ b/objc/oclib/msgxpr.m
@@ -273,8 +273,7 @@ id msgwraps; /* VICI */
 
             if (![argType isTypeEqual:methType])
             {
-                dbg ("[[msg argAt:i] expr] = %s\n",
-                       [[[msg argAt:i] expr] str]);
+                dbg ("[[msg argAt:i] expr] = %s\n", [[[msg argAt:i] expr] str]);
                 warnat (msg, "incompatible type '%s' specified to '%s:(%s)' ",
                         [[argType asDefFor:nil] str],
                         [[[msg argAt:i] keyw] str],

--- a/objc/oclib/protodef.h
+++ b/objc/oclib/protodef.h
@@ -8,6 +8,7 @@
 }
 
 @property id protoname;
+@property Dictionary * generics;
 
 - (int)compare:c;
 

--- a/objc/oclib/switstmt.h
+++ b/objc/oclib/switstmt.h
@@ -17,9 +17,4 @@
  */
 
 @interface SwitchStmt : IfStmt
-{
-}
-
-- st80;
-
 @end

--- a/objc/oclib/type.h
+++ b/objc/oclib/type.h
@@ -89,7 +89,7 @@ extern id t_id;
 
 - (ClassDef *)getClass;
 - (GenericSpec *)getGenSpec;
-- (GenericDecl *)genDeclForClass:aClass;
+- (Type *)genDeclForClass:aClass;
 
 - encode:nested;
 - encode;
@@ -97,12 +97,6 @@ extern id t_id;
 - star;
 - funcall;
 - ampersand;
-
-- zero;
-- peekAt:(char *)ptr;
-- poke:v at:(char *)ptr;
-
-- (int)bytesize;
 
 @end
 

--- a/objc/oclib/type.h
+++ b/objc/oclib/type.h
@@ -32,6 +32,8 @@ extern id t_id;
 #ifndef TYPE__H__
 #define TYPE__H__
 
+@class GenericSpec;
+@class GenericDecl;
 @class ClassDef;
 @class String;
 
@@ -80,9 +82,12 @@ extern id t_id;
 - (BOOL)canforward;
 - (BOOL)isscalartype;
 - (BOOL)isselptr;
+- (BOOL)isGenSpec;
 - (BOOL)isTypeEqual:x;
 
 - (ClassDef *)getClass;
+- (GenericSpec *)getGenSpec;
+- (GenericDecl *)genDeclForClass:aClass;
 
 - encode:nested;
 - encode;

--- a/objc/oclib/type.h
+++ b/objc/oclib/type.h
@@ -16,6 +16,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "node.h"
+
 extern id t_unknown;
 extern id t_void;
 extern id t_char;

--- a/objc/oclib/type.m
+++ b/objc/oclib/type.m
@@ -443,9 +443,8 @@ BASIC_TYPESPECS basicSpecForSpec (id spec)
 
         if (!matched && (potentialType = [trlunit lookuptype:each]))
         {
-            dbg ("Potential type for <%s>: <%s>\n",
-                    [[self asDefFor:nil] str],
-                    [[potentialType asDefFor:nil] str]);
+            dbg ("Potential type for <%s>: <%s>\n", [[self asDefFor:nil] str],
+                 [[potentialType asDefFor:nil] str]);
             matched =
                 [potentialType isTypeEqual:x] ?: [x isTypeEqual:potentialType];
         }
@@ -523,22 +522,12 @@ BASIC_TYPESPECS basicSpecForSpec (id spec)
     return NO;
 }
 
-- (GenericDecl *)genDeclForClass:aClass
+- (Type *)genDeclForClass:aClass
 {
     if ([decl isKindOf:GenericDecl])
         return self;
     else
-    {
-        Type * pType = nil;
-
-        [specs do:
-               { :each | Type * tmpT;
-                   if ((tmpT = [[aClass generics] atKey:each]))
-                       pType = tmpT;
-               }];
-
-        return pType;
-    }
+        return nil; /* generics resolved at typename formation now */
 }
 
 - (BOOL)isGenSpec
@@ -701,6 +690,7 @@ BASIC_TYPESPECS basicSpecForSpec (id spec)
             [sym gen];
     }
     o_nolinetags--;
+
     return self;
 }
 
@@ -760,65 +750,6 @@ BASIC_TYPESPECS basicSpecForSpec (id spec)
     if (decl == nil && [specs size] != 1)
         return nil;
     return [[self copy] abstrdecl:[decl funcall]];
-}
-
-- zero
-{
-    if ([self isEqual:t_id])
-        return nil;
-    if ([self isEqual:t_str])
-        return [[Scalar new] u_str:NULL];
-    if ([decl isKindOf:(id)[ArrayDecl class]] && [specs size] == 1)
-    {
-        id s;
-        int n = [[decl expr] asInt];
-        s     = [Symbol new:n];
-        return [[Scalar new] u_str:[s strCopy]];
-    }
-    if (decl == nil && [specs size] == 1)
-    {
-        return [[specs at:0] zero];
-    }
-    return nil;
-}
-
-- peekAt:(char *)ptr
-{
-    if (decl == nil && [specs size] == 1)
-    {
-        return [[specs at:0] peekAt:ptr];
-    }
-    else
-    {
-        [self notImplemented:_cmd];
-        return 0;
-    }
-}
-
-- poke:v at:(char *)ptr
-{
-    if (decl == nil && [specs size] == 1)
-    {
-        return [[specs at:0] poke:v at:ptr];
-    }
-    else
-    {
-        [self notImplemented:_cmd];
-        return 0;
-    }
-}
-
-- (int)bytesize
-{
-    if (decl == nil && [specs size] == 1)
-    {
-        return [[specs at:0] bytesize];
-    }
-    else
-    {
-        [self notImplemented:_cmd];
-        return 0;
-    }
 }
 
 @end

--- a/objc/oclib/type.m
+++ b/objc/oclib/type.m
@@ -443,7 +443,7 @@ BASIC_TYPESPECS basicSpecForSpec (id spec)
 
         if (!matched && (potentialType = [trlunit lookuptype:each]))
         {
-            printf ("Potential type for <%s>: <%s>\n",
+            dbg ("Potential type for <%s>: <%s>\n",
                     [[self asDefFor:nil] str],
                     [[potentialType asDefFor:nil] str]);
             matched =

--- a/objc/oclib/util.m
+++ b/objc/oclib/util.m
@@ -1113,9 +1113,6 @@ id mkclassdef (id keyw, id name, id sname, id protocols, id ivars, id cvars,
                       Type * newType = [[t_id deepCopy] decl:gDecl];
                       [trlunit def:each astype:newType];
                       [clsGenerics atKey:each put:newType];
-                      /* A better option: make the generic types temporarily a
-                         different token that is resolved into an <id> type. */
-                      gf ("typedef id %s;\n", [each str]);
                   }];
         [r setGenerics:clsGenerics];
     }
@@ -1249,11 +1246,22 @@ id mklistexpr (id lb, id x, id rb)
 
 id mktypename (id specs, id decl)
 {
-    id r = [Type new];
+    Type * nType = nil;
 
-    [r specs:specs];
-    [r decl:decl];
-    return r;
+    if (curclassdef) /* handle case of generics as early as possible */
+        [specs do:
+               { :each | Type * tmpT;
+                   if ((tmpT = [[curclassdef generics] atKey:each]))
+                       nType = tmpT;
+               }];
+
+    if (!nType)
+    {
+        nType = [Type new];
+        [nType specs:specs];
+        [nType decl:decl];
+    }
+    return nType;
 }
 
 id mkcomponentdef (id cdef, id specs, id decl)

--- a/objc/oclib/util.m
+++ b/objc/oclib/util.m
@@ -135,7 +135,7 @@ void finclassdef (void)
             [curclassdef synthpropmethods];
 
         [[curclassdef generics]
-            do:{ : each | [trlunit undefSym:[[each decl] sym] asType:each]}];
+            keysDo:{ : eachKey | [trlunit undefSym:eachKey asType:[[curclassdef generics] atKey:eachKey]]}];
 
         if (o_warnmissingmethods && [curclassdef isimpl])
         {
@@ -1099,19 +1099,23 @@ id mkclassdef (id keyw, id name, id sname, id protocols, id ivars, id cvars,
         [r supername:sname];
         [r ivars:ivars];
         [r cvars:cvars];
-        [r setGenerics:generics];
     }
 
     if (generics)
     {
-        OrdCltn * clsGenerics = [OrdCltn new];
-        short i               = 0;
+        Dictionary * clsGenerics = [Dictionary new];
+        short i                  = 0;
 
         [generics do:
                   { :each |
-          Type * newType =[[t_id deepCopy] decl:[[[GenericDecl new] setIndex:i++] setSym:each]];
+                      GenericDecl * gDecl =  [[[GenericDecl new] 
+                                               setIndex:i++] setSym:each];
+                      Type * newType = [[t_id deepCopy] decl:gDecl];
                       [trlunit def:each astype:newType];
-                      [clsGenerics add:newType];
+                      [clsGenerics atKey:each put:newType];
+                      /* A better option: make the generic types temporarily a
+                         different token that is resolved into an <id> type. */
+                      gf ("typedef id %s;\n", [each str]);
                   }];
         [r setGenerics:clsGenerics];
     }

--- a/objc/yacc.ym
+++ b/objc/yacc.ym
@@ -280,7 +280,7 @@ protolist
     ;
 
 optprotoreflist
-    : relop protolist relop { $$ = $2; }
+    : angleopen protolist angleclose { $$ = $2; }
     | { $$ = nil; }
     ;
 
@@ -300,7 +300,7 @@ genericnamelist
     ;
 
 genericnames
-    : relop genericnamelist relop { $$ = $2; }
+    : angleopen genericnamelist angleclose { $$ = $2; }
     ;
 
 optgenericnames

--- a/objc/yacc.ym
+++ b/objc/yacc.ym
@@ -29,6 +29,7 @@
 #include "util.h"
 #include "stmt.h"
 #include "trlunit.h"
+#include "genspec.h"
 
 #ifndef __WATCOMC__
 /* breaks compile wcc386 */
@@ -1126,7 +1127,7 @@ typenamelist
 
 genericspec
     : angleopen typenamelist angleclose
-    { $$ = $2; }
+    { $$ = [[GenericSpec new] setTypes: $2]; }
     ;
 
 typespec


### PR DESCRIPTION
The lightweight generics are now working well enough. The syntax confuses clang-scanner and causes problems, but this is not a big problem. They are working now and do not use typedeffing any more.